### PR TITLE
controller create page

### DIFF
--- a/src/controllers/articleCreateController.js
+++ b/src/controllers/articleCreateController.js
@@ -1,0 +1,45 @@
+import Article from '../db/models/articleModel.js';
+import mongoose from 'mongoose';
+import createHttpError from 'http-errors';
+
+export const createArticleFromForm = async (req, res, next) => {
+  try {
+    const { title, article, date, author } = req.body;
+
+    if (!title || title.length < 3 || title.length > 48) {
+      throw createHttpError(400, 'Title must be between 3 and 48 characters');
+    }
+
+    if (!article || article.length < 100 || article.length > 4000) {
+      throw createHttpError(400, 'Article must be between 100 and 4000 characters');
+    }
+
+    if (!date || isNaN(Date.parse(date))) {
+      throw createHttpError(400, 'Date is required and must be a valid date');
+    }
+
+    if (!author || !mongoose.Types.ObjectId.isValid(author)) {
+      throw createHttpError(400, 'Invalid or missing author');
+    }
+
+    if (!req.file) {
+      throw createHttpError(400, 'Image is required');
+    }
+
+    if (req.file.size > 1024 * 1024) {
+      throw createHttpError(400, 'Image size exceeds 1MB');
+    }
+
+    const newArticle = await Article.create({
+      title,
+      article,
+      img: req.file.filename,
+      createdAt: new Date(date),
+      author,
+    });
+
+    res.status(201).json({ _id: newArticle._id });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/controllers/articlesController.js
+++ b/src/controllers/articlesController.js
@@ -92,6 +92,10 @@ export const deleteAllArticles = async (req, res, next) => {
   }
 };
 
+// ❌ Вимкнено: createSingleArticle
+// Замість цього використовується createArticleFromForm з підтримкою файлів
+
+/*
 export const createSingleArticle = async (req, res, next) => {
   try {
     const newArticle = await Article.create({
@@ -103,6 +107,7 @@ export const createSingleArticle = async (req, res, next) => {
     next(err);
   }
 };
+*/
 
 export const fetchSavedArticles = async (req, res, next) => {
   try {

--- a/src/routers/articlesRouter.js
+++ b/src/routers/articlesRouter.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import multer from 'multer';
 import {
   fetchArticleById,
   fetchRecommendedArticles,
@@ -13,17 +14,38 @@ import {
   removeSavedArticle,
   fetchPopularArticles,
 } from '../controllers/articlesController.js';
+import { createArticleFromForm } from '../controllers/articleCreateController.js'; // 🆕 Імпорт нового контролера
 import { authenticate } from '../middlewares/authenticate.js';
 
 const router = express.Router();
+
+// Налаштування multer для обробки файлів (одне зображення)
+const upload = multer({
+  limits: {
+    fileSize: 1024 * 1024, // 1MB
+  },
+  fileFilter(req, file, cb) {
+    if (!file.mimetype.startsWith('image/')) {
+      return cb(new Error('Тільки зображення дозволені'));
+    }
+    cb(null, true);
+  },
+});
+
+
 
 router.get('/', fetchAllArticles);
 
 router.get('/popular', fetchPopularArticles);
 
-router.post('/create', authenticate, createSingleArticle);
+// 🆕 ОНОВЛЕНО: створення статті тепер через multipart/form-data + авторизація
+router.post(
+  '/create',
+    authenticate,
+  upload.single('image'),
+  createArticleFromForm
+);
 
-router.patch('/:id', authenticate, updateArticleById);
 
 router.delete('/all', deleteAllArticles);
 
@@ -35,9 +57,11 @@ router.delete('/:id/save', authenticate, removeSavedArticle);
 
 router.get('/saved', authenticate, fetchSavedArticles);
 
+
 router.get('/recommend', fetchRecommendedArticles);
 
 router.get('/:id', fetchArticleById);
+
 
 router.post('/', createManyArticles);
 


### PR DESCRIPTION
Що зроблено 
Додано окремий контролер createArticleFromForm

Файл: articleCreateController.js

Призначення: Обробка створення статей, що надсилаються з форми як multipart/form-data.

Валідація включає: 

title: 3–48 символів

article: 100–4000 символів

date: обов'язкова та коректна дата

author: обов'язковий і валідний ObjectId

image: обов'язковий файл, лише зображення, розмір до 1MB

✅ 2. Оновлено маршрути в articlesRoutes.js

Файл: articlesRoutes.js

Зміни:

Додано імпорт createArticleFromForm

Додано новий роут:

router.post('/create', authenticate, upload.single('image'), createArticleFromForm);


Завантаження одного зображення через multer

Ціль: Приймати лише зображення розміром до 1MB

Валідація MIME-типу: лише image